### PR TITLE
Add 'self' to data structure definitions in Pomodoro

### DIFF
--- a/plugins/pomodoro.py
+++ b/plugins/pomodoro.py
@@ -6,8 +6,8 @@ import bot
 class Pomodoro():
     """A pomodoro timer."""
     def __init__(self):
-        pomodoros = []
-        commands = {"start": self.pomodoro_start,
+        self.pomodoros = []
+        self.commands = {"start": self.pomodoro_start,
                     "clear": self.clear_pomodoros}
     def pomo(self):
         pass


### PR DESCRIPTION
Forgot to write the definitions in dot notation so that they're actually a part of the pomodoro object and not just the namespace of the **init** function.
